### PR TITLE
update sst gold files because of AMO register addition

### DIFF
--- a/src/sst/elements/vanadis/tests/small/basic-io/hello-world/riscv64/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/basic-io/hello-world/riscv64/sst.stdout.gold
@@ -36,6 +36,6 @@ l2cache: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated to
  v0.rob_slots_in_use.1 : Accumulator : Sum.u64 = 1457468; SumSQ.u64 = 86973064; Count.u64 = 53038; Min.u64 = 0; Max.u64 = 63; 
  v0.rob_cleared_entries.1 : Accumulator : Sum.u64 = 5308; SumSQ.u64 = 268010; Count.u64 = 145; Min.u64 = 0; Max.u64 = 62; 
  v0.syscall-cycles.1 : Accumulator : Sum.u64 = 15; SumSQ.u64 = 15; Count.u64 = 15; Min.u64 = 1; Max.u64 = 1; 
- v0.phys_int_reg_in_use.1 : Accumulator : Sum.u64 = 1813006; SumSQ.u64 = 62351952; Count.u64 = 53038; Min.u64 = 32; Max.u64 = 49; 
+ v0.phys_int_reg_in_use.1 : Accumulator : Sum.u64 = 1919082; SumSQ.u64 = 69816128; Count.u64 = 53038; Min.u64 = 34; Max.u64 = 51; 
  v0.phys_fp_reg_in_use.1 : Accumulator : Sum.u64 = 1697216; SumSQ.u64 = 54310912; Count.u64 = 53038; Min.u64 = 32; Max.u64 = 32; 
 Simulation is complete, simulated time: 23.1838 us

--- a/src/sst/elements/vanadis/tests/small/basic-io/openat/riscv64/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/basic-io/openat/riscv64/sst.stdout.gold
@@ -36,6 +36,6 @@ l2cache: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated to
  v0.rob_slots_in_use.1 : Accumulator : Sum.u64 = 3455389; SumSQ.u64 = 203337383; Count.u64 = 110325; Min.u64 = 0; Max.u64 = 63; 
  v0.rob_cleared_entries.1 : Accumulator : Sum.u64 = 71632; SumSQ.u64 = 3698340; Count.u64 = 1698; Min.u64 = 0; Max.u64 = 62; 
  v0.syscall-cycles.1 : Accumulator : Sum.u64 = 59; SumSQ.u64 = 59; Count.u64 = 59; Min.u64 = 1; Max.u64 = 1; 
- v0.phys_int_reg_in_use.1 : Accumulator : Sum.u64 = 3855564; SumSQ.u64 = 136256248; Count.u64 = 110325; Min.u64 = 32; Max.u64 = 51; 
+ v0.phys_int_reg_in_use.1 : Accumulator : Sum.u64 = 4076214; SumSQ.u64 = 152119804; Count.u64 = 110325; Min.u64 = 34; Max.u64 = 53; 
  v0.phys_fp_reg_in_use.1 : Accumulator : Sum.u64 = 3530400; SumSQ.u64 = 112972800; Count.u64 = 110325; Min.u64 = 32; Max.u64 = 32; 
 Simulation is complete, simulated time: 49.1711 us

--- a/src/sst/elements/vanadis/tests/small/basic-io/printf-check/riscv64/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/basic-io/printf-check/riscv64/sst.stdout.gold
@@ -36,6 +36,6 @@ l2cache: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated to
  v0.rob_slots_in_use.1 : Accumulator : Sum.u64 = 3201128; SumSQ.u64 = 183083820; Count.u64 = 147146; Min.u64 = 0; Max.u64 = 63; 
  v0.rob_cleared_entries.1 : Accumulator : Sum.u64 = 51787; SumSQ.u64 = 2611683; Count.u64 = 1347; Min.u64 = 0; Max.u64 = 62; 
  v0.syscall-cycles.1 : Accumulator : Sum.u64 = 19; SumSQ.u64 = 19; Count.u64 = 19; Min.u64 = 1; Max.u64 = 1; 
- v0.phys_int_reg_in_use.1 : Accumulator : Sum.u64 = 5001639; SumSQ.u64 = 171407957; Count.u64 = 147146; Min.u64 = 32; Max.u64 = 51; 
+ v0.phys_int_reg_in_use.1 : Accumulator : Sum.u64 = 5295931; SumSQ.u64 = 192003097; Count.u64 = 147146; Min.u64 = 34; Max.u64 = 53; 
  v0.phys_fp_reg_in_use.1 : Accumulator : Sum.u64 = 4708726; SumSQ.u64 = 150681014; Count.u64 = 147146; Min.u64 = 32; Max.u64 = 33; 
 Simulation is complete, simulated time: 64.2195 us

--- a/src/sst/elements/vanadis/tests/small/basic-io/unlink/riscv64/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/basic-io/unlink/riscv64/sst.stdout.gold
@@ -36,6 +36,6 @@ l2cache: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated to
  v0.rob_slots_in_use.1 : Accumulator : Sum.u64 = 2426682; SumSQ.u64 = 143373296; Count.u64 = 86631; Min.u64 = 0; Max.u64 = 63; 
  v0.rob_cleared_entries.1 : Accumulator : Sum.u64 = 27885; SumSQ.u64 = 1443189; Count.u64 = 678; Min.u64 = 0; Max.u64 = 62; 
  v0.syscall-cycles.1 : Accumulator : Sum.u64 = 31; SumSQ.u64 = 31; Count.u64 = 31; Min.u64 = 1; Max.u64 = 1; 
- v0.phys_int_reg_in_use.1 : Accumulator : Sum.u64 = 2964750; SumSQ.u64 = 102199224; Count.u64 = 86631; Min.u64 = 32; Max.u64 = 50; 
+ v0.phys_int_reg_in_use.1 : Accumulator : Sum.u64 = 3138012; SumSQ.u64 = 114404748; Count.u64 = 86631; Min.u64 = 34; Max.u64 = 52; 
  v0.phys_fp_reg_in_use.1 : Accumulator : Sum.u64 = 2772192; SumSQ.u64 = 88710144; Count.u64 = 86631; Min.u64 = 32; Max.u64 = 32; 
 Simulation is complete, simulated time: 38.3452 us

--- a/src/sst/elements/vanadis/tests/small/basic-io/unlinkat/riscv64/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/basic-io/unlinkat/riscv64/sst.stdout.gold
@@ -36,6 +36,6 @@ l2cache: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated to
  v0.rob_slots_in_use.1 : Accumulator : Sum.u64 = 2424928; SumSQ.u64 = 143565342; Count.u64 = 85287; Min.u64 = 0; Max.u64 = 63; 
  v0.rob_cleared_entries.1 : Accumulator : Sum.u64 = 27829; SumSQ.u64 = 1419081; Count.u64 = 693; Min.u64 = 0; Max.u64 = 62; 
  v0.syscall-cycles.1 : Accumulator : Sum.u64 = 31; SumSQ.u64 = 31; Count.u64 = 31; Min.u64 = 1; Max.u64 = 1; 
- v0.phys_int_reg_in_use.1 : Accumulator : Sum.u64 = 2938395; SumSQ.u64 = 102218925; Count.u64 = 85287; Min.u64 = 32; Max.u64 = 51; 
+ v0.phys_int_reg_in_use.1 : Accumulator : Sum.u64 = 3108969; SumSQ.u64 = 114313653; Count.u64 = 85287; Min.u64 = 34; Max.u64 = 53; 
  v0.phys_fp_reg_in_use.1 : Accumulator : Sum.u64 = 2729184; SumSQ.u64 = 87333888; Count.u64 = 85287; Min.u64 = 32; Max.u64 = 32; 
 Simulation is complete, simulated time: 37.7593 us

--- a/src/sst/elements/vanadis/tests/small/basic-math/sqrt-double/riscv64/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/basic-math/sqrt-double/riscv64/sst.stdout.gold
@@ -36,6 +36,6 @@ l2cache: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated to
  v0.rob_slots_in_use.1 : Accumulator : Sum.u64 = 1295499885; SumSQ.u64 = 81292887873; Count.u64 = 20808744; Min.u64 = 0; Max.u64 = 63; 
  v0.rob_cleared_entries.1 : Accumulator : Sum.u64 = 494752; SumSQ.u64 = 25092994; Count.u64 = 12314; Min.u64 = 0; Max.u64 = 62; 
  v0.syscall-cycles.1 : Accumulator : Sum.u64 = 103; SumSQ.u64 = 103; Count.u64 = 103; Min.u64 = 1; Max.u64 = 1; 
- v0.phys_int_reg_in_use.1 : Accumulator : Sum.u64 = 674766346; SumSQ.u64 = 21891697418; Count.u64 = 20808744; Min.u64 = 32; Max.u64 = 51; 
+ v0.phys_int_reg_in_use.1 : Accumulator : Sum.u64 = 716383834; SumSQ.u64 = 24673997778; Count.u64 = 20808744; Min.u64 = 34; Max.u64 = 53; 
  v0.phys_fp_reg_in_use.1 : Accumulator : Sum.u64 = 692171814; SumSQ.u64 = 23030766200; Count.u64 = 20808744; Min.u64 = 32; Max.u64 = 35; 
 Simulation is complete, simulated time: 9.05377 ms

--- a/src/sst/elements/vanadis/tests/small/basic-math/sqrt-float/riscv64/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/basic-math/sqrt-float/riscv64/sst.stdout.gold
@@ -36,6 +36,6 @@ l2cache: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated to
  v0.rob_slots_in_use.1 : Accumulator : Sum.u64 = 1291670139; SumSQ.u64 = 81067062865; Count.u64 = 20727536; Min.u64 = 0; Max.u64 = 63; 
  v0.rob_cleared_entries.1 : Accumulator : Sum.u64 = 381622; SumSQ.u64 = 18898870; Count.u64 = 10005; Min.u64 = 0; Max.u64 = 62; 
  v0.syscall-cycles.1 : Accumulator : Sum.u64 = 103; SumSQ.u64 = 103; Count.u64 = 103; Min.u64 = 1; Max.u64 = 1; 
- v0.phys_int_reg_in_use.1 : Accumulator : Sum.u64 = 671958253; SumSQ.u64 = 21793857975; Count.u64 = 20727536; Min.u64 = 32; Max.u64 = 51; 
+ v0.phys_int_reg_in_use.1 : Accumulator : Sum.u64 = 713413325; SumSQ.u64 = 24564601131; Count.u64 = 20727536; Min.u64 = 34; Max.u64 = 53; 
  v0.phys_fp_reg_in_use.1 : Accumulator : Sum.u64 = 689537201; SumSQ.u64 = 22945253797; Count.u64 = 20727536; Min.u64 = 32; Max.u64 = 35; 
 Simulation is complete, simulated time: 9.01844 ms

--- a/src/sst/elements/vanadis/tests/small/basic-ops/test-branch/riscv64/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/basic-ops/test-branch/riscv64/sst.stdout.gold
@@ -36,6 +36,6 @@ l2cache: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated to
  v0.rob_slots_in_use.1 : Accumulator : Sum.u64 = 46378373; SumSQ.u64 = 2309877397; Count.u64 = 1339069; Min.u64 = 0; Max.u64 = 63; 
  v0.rob_cleared_entries.1 : Accumulator : Sum.u64 = 6981548; SumSQ.u64 = 402780546; Count.u64 = 133713; Min.u64 = 0; Max.u64 = 62; 
  v0.syscall-cycles.1 : Accumulator : Sum.u64 = 15; SumSQ.u64 = 15; Count.u64 = 15; Min.u64 = 1; Max.u64 = 1; 
- v0.phys_int_reg_in_use.1 : Accumulator : Sum.u64 = 45599699; SumSQ.u64 = 1555576029; Count.u64 = 1339069; Min.u64 = 32; Max.u64 = 49; 
+ v0.phys_int_reg_in_use.1 : Accumulator : Sum.u64 = 48277837; SumSQ.u64 = 1743331101; Count.u64 = 1339069; Min.u64 = 34; Max.u64 = 51; 
  v0.phys_fp_reg_in_use.1 : Accumulator : Sum.u64 = 42850208; SumSQ.u64 = 1371206656; Count.u64 = 1339069; Min.u64 = 32; Max.u64 = 32; 
 Simulation is complete, simulated time: 582.619 us

--- a/src/sst/elements/vanadis/tests/small/basic-ops/test-shift/riscv64/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/basic-ops/test-shift/riscv64/sst.stdout.gold
@@ -36,6 +36,6 @@ l2cache: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated to
  v0.rob_slots_in_use.1 : Accumulator : Sum.u64 = 100166213; SumSQ.u64 = 5786157565; Count.u64 = 2136433; Min.u64 = 0; Max.u64 = 63; 
  v0.rob_cleared_entries.1 : Accumulator : Sum.u64 = 5888193; SumSQ.u64 = 310394553; Count.u64 = 128081; Min.u64 = 0; Max.u64 = 62; 
  v0.syscall-cycles.1 : Accumulator : Sum.u64 = 67; SumSQ.u64 = 67; Count.u64 = 67; Min.u64 = 1; Max.u64 = 1; 
- v0.phys_int_reg_in_use.1 : Accumulator : Sum.u64 = 77236606; SumSQ.u64 = 2810537868; Count.u64 = 2136433; Min.u64 = 32; Max.u64 = 49; 
+ v0.phys_int_reg_in_use.1 : Accumulator : Sum.u64 = 81509472; SumSQ.u64 = 3128030024; Count.u64 = 2136433; Min.u64 = 34; Max.u64 = 51; 
  v0.phys_fp_reg_in_use.1 : Accumulator : Sum.u64 = 68365856; SumSQ.u64 = 2187707392; Count.u64 = 2136433; Min.u64 = 32; Max.u64 = 32; 
 Simulation is complete, simulated time: 934.897 us

--- a/src/sst/elements/vanadis/tests/small/misc/gettime/riscv64/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/misc/gettime/riscv64/sst.stdout.gold
@@ -36,6 +36,6 @@ l2cache: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated to
  v0.rob_slots_in_use.1 : Accumulator : Sum.u64 = 2205921; SumSQ.u64 = 128242241; Count.u64 = 83964; Min.u64 = 0; Max.u64 = 63; 
  v0.rob_cleared_entries.1 : Accumulator : Sum.u64 = 25557; SumSQ.u64 = 1288433; Count.u64 = 631; Min.u64 = 0; Max.u64 = 62; 
  v0.syscall-cycles.1 : Accumulator : Sum.u64 = 23; SumSQ.u64 = 23; Count.u64 = 23; Min.u64 = 1; Max.u64 = 1; 
- v0.phys_int_reg_in_use.1 : Accumulator : Sum.u64 = 2873289; SumSQ.u64 = 99102079; Count.u64 = 83964; Min.u64 = 32; Max.u64 = 49; 
+ v0.phys_int_reg_in_use.1 : Accumulator : Sum.u64 = 3041217; SumSQ.u64 = 110931091; Count.u64 = 83964; Min.u64 = 34; Max.u64 = 51; 
  v0.phys_fp_reg_in_use.1 : Accumulator : Sum.u64 = 2686848; SumSQ.u64 = 85979136; Count.u64 = 83964; Min.u64 = 32; Max.u64 = 32; 
 Simulation is complete, simulated time: 36.7414 us

--- a/src/sst/elements/vanadis/tests/small/misc/mt-dgemm/riscv64/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/misc/mt-dgemm/riscv64/sst.stdout.gold
@@ -36,6 +36,6 @@ l2cache: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated to
  v0.rob_slots_in_use.1 : Accumulator : Sum.u64 = 328082885; SumSQ.u64 = 20492855507; Count.u64 = 5396281; Min.u64 = 0; Max.u64 = 63; 
  v0.rob_cleared_entries.1 : Accumulator : Sum.u64 = 628234; SumSQ.u64 = 37110348; Count.u64 = 11365; Min.u64 = 0; Max.u64 = 62; 
  v0.syscall-cycles.1 : Accumulator : Sum.u64 = 28; SumSQ.u64 = 28; Count.u64 = 28; Min.u64 = 1; Max.u64 = 1; 
- v0.phys_int_reg_in_use.1 : Accumulator : Sum.u64 = 183540647; SumSQ.u64 = 6256551953; Count.u64 = 5396281; Min.u64 = 32; Max.u64 = 51; 
+ v0.phys_int_reg_in_use.1 : Accumulator : Sum.u64 = 194333209; SumSQ.u64 = 7012299665; Count.u64 = 5396281; Min.u64 = 34; Max.u64 = 53; 
  v0.phys_fp_reg_in_use.1 : Accumulator : Sum.u64 = 181487022; SumSQ.u64 = 6110183740; Count.u64 = 5396281; Min.u64 = 32; Max.u64 = 41; 
 Simulation is complete, simulated time: 2.34774 ms

--- a/src/sst/elements/vanadis/tests/small/misc/splitLoad/riscv64/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/misc/splitLoad/riscv64/sst.stdout.gold
@@ -36,6 +36,6 @@ l2cache: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated to
  v0.rob_slots_in_use.1 : Accumulator : Sum.u64 = 6170006; SumSQ.u64 = 357958162; Count.u64 = 161378; Min.u64 = 0; Max.u64 = 63; 
  v0.rob_cleared_entries.1 : Accumulator : Sum.u64 = 239855; SumSQ.u64 = 12769703; Count.u64 = 5198; Min.u64 = 0; Max.u64 = 62; 
  v0.syscall-cycles.1 : Accumulator : Sum.u64 = 19; SumSQ.u64 = 19; Count.u64 = 19; Min.u64 = 1; Max.u64 = 1; 
- v0.phys_int_reg_in_use.1 : Accumulator : Sum.u64 = 5738572; SumSQ.u64 = 205863332; Count.u64 = 161378; Min.u64 = 32; Max.u64 = 49; 
+ v0.phys_int_reg_in_use.1 : Accumulator : Sum.u64 = 6061328; SumSQ.u64 = 229463132; Count.u64 = 161378; Min.u64 = 34; Max.u64 = 51; 
  v0.phys_fp_reg_in_use.1 : Accumulator : Sum.u64 = 5164096; SumSQ.u64 = 165251072; Count.u64 = 161378; Min.u64 = 32; Max.u64 = 32; 
 Simulation is complete, simulated time: 70.5183 us

--- a/src/sst/elements/vanadis/tests/small/misc/stream/riscv64/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/misc/stream/riscv64/sst.stdout.gold
@@ -36,6 +36,6 @@ l2cache: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated to
  v0.rob_slots_in_use.1 : Accumulator : Sum.u64 = 59429371; SumSQ.u64 = 3653415035; Count.u64 = 1183373; Min.u64 = 0; Max.u64 = 63; 
  v0.rob_cleared_entries.1 : Accumulator : Sum.u64 = 399462; SumSQ.u64 = 20472910; Count.u64 = 9811; Min.u64 = 0; Max.u64 = 62; 
  v0.syscall-cycles.1 : Accumulator : Sum.u64 = 1472; SumSQ.u64 = 1472; Count.u64 = 1472; Min.u64 = 1; Max.u64 = 1; 
- v0.phys_int_reg_in_use.1 : Accumulator : Sum.u64 = 40245411; SumSQ.u64 = 1374922197; Count.u64 = 1183373; Min.u64 = 32; Max.u64 = 51; 
+ v0.phys_int_reg_in_use.1 : Accumulator : Sum.u64 = 42612157; SumSQ.u64 = 1540637333; Count.u64 = 1183373; Min.u64 = 34; Max.u64 = 53; 
  v0.phys_fp_reg_in_use.1 : Accumulator : Sum.u64 = 38680910; SumSQ.u64 = 1265279870; Count.u64 = 1183373; Min.u64 = 32; Max.u64 = 45; 
 Simulation is complete, simulated time: 526.882 us


### PR DESCRIPTION
AMO adds 2 ISA registers that consume two physical registers when initialized. This changes the statistics.